### PR TITLE
refactor: DB와의 구분을 위해 QnaLike, QnaScrap으로 이름 변경

### DIFF
--- a/src/main/java/com/example/zzbb/qna/controller/QnaController.java
+++ b/src/main/java/com/example/zzbb/qna/controller/QnaController.java
@@ -3,12 +3,8 @@ package com.example.zzbb.qna.controller;
 import com.example.zzbb.global.ApiResponse;
 import com.example.zzbb.jwt.JwtUtil;
 import com.example.zzbb.qna.dto.*;
-import com.example.zzbb.qna.entity.Comment;
-import com.example.zzbb.qna.entity.Likes;
-import com.example.zzbb.qna.entity.QnaImage;
-import com.example.zzbb.qna.entity.Scrap;
+import com.example.zzbb.qna.entity.QnaComment;
 import com.example.zzbb.qna.service.QnaService;
-import com.example.zzbb.qna.service.S3Service;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -84,8 +80,8 @@ public class QnaController {
         String accessToken = jwtUtil.extractToken(authorizationHeader);
         String username = jwtUtil.extractUsername(accessToken);
         // 2. 서비스에서 처리
-        Comment comment = qnaService.commentQna(qnaId, username, request);
-        return comment != null?
+        QnaComment qnaComment = qnaService.commentQna(qnaId, username, request);
+        return qnaComment != null?
                 ResponseEntity.ok(ApiResponse.created(null)):
                 ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ApiResponse.error(500, "댓글 달기에 실패했습니다."));
     }

--- a/src/main/java/com/example/zzbb/qna/entity/Qna.java
+++ b/src/main/java/com/example/zzbb/qna/entity/Qna.java
@@ -48,7 +48,7 @@ public class Qna {
     private List<QnaLike> qnaLikes = new ArrayList<>();
 
     @OneToMany(mappedBy = "qna", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Scrap> scraps = new ArrayList<>();
+    private List<QnaScrap> qnaScraps = new ArrayList<>();
 
     @Column(nullable = false)
     private String generatedTime;

--- a/src/main/java/com/example/zzbb/qna/entity/Qna.java
+++ b/src/main/java/com/example/zzbb/qna/entity/Qna.java
@@ -42,10 +42,10 @@ public class Qna {
     private List<QnaHashtag> qnaHashtags = new ArrayList<>();
 
     @OneToMany(mappedBy = "qna", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Comment> comments = new ArrayList<>();
+    private List<QnaComment> qnaComments = new ArrayList<>();
 
     @OneToMany(mappedBy = "qna", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Likes> likes = new ArrayList<>();
+    private List<QnaLike> qnaLikes = new ArrayList<>();
 
     @OneToMany(mappedBy = "qna", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Scrap> scraps = new ArrayList<>();

--- a/src/main/java/com/example/zzbb/qna/entity/QnaComment.java
+++ b/src/main/java/com/example/zzbb/qna/entity/QnaComment.java
@@ -12,7 +12,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class Comment {
+public class QnaComment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer commentId;

--- a/src/main/java/com/example/zzbb/qna/entity/QnaLike.java
+++ b/src/main/java/com/example/zzbb/qna/entity/QnaLike.java
@@ -12,7 +12,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class Likes {
+public class QnaLike {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer likeId;

--- a/src/main/java/com/example/zzbb/qna/entity/QnaScrap.java
+++ b/src/main/java/com/example/zzbb/qna/entity/QnaScrap.java
@@ -12,7 +12,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class Scrap {
+public class QnaScrap {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer scrapId;

--- a/src/main/java/com/example/zzbb/qna/repository/CommentRepository.java
+++ b/src/main/java/com/example/zzbb/qna/repository/CommentRepository.java
@@ -1,6 +1,6 @@
 package com.example.zzbb.qna.repository;
 
-import com.example.zzbb.qna.entity.Comment;
+import com.example.zzbb.qna.entity.QnaComment;
 import com.example.zzbb.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 import java.util.ArrayList;
 
 @Repository
-public interface CommentRepository extends JpaRepository<Comment, Integer> {
-    @Query("SELECT c FROM Comment c WHERE c.qna = :qna ORDER BY c.generatedTime ASC")
-    ArrayList<Comment> findByUser(User user);
+public interface CommentRepository extends JpaRepository<QnaComment, Integer> {
+    @Query("SELECT c FROM QnaComment c WHERE c.qna = :qna ORDER BY c.generatedTime ASC")
+    ArrayList<QnaComment> findByUser(User user);
 }

--- a/src/main/java/com/example/zzbb/qna/repository/LikeRepository.java
+++ b/src/main/java/com/example/zzbb/qna/repository/LikeRepository.java
@@ -1,6 +1,6 @@
 package com.example.zzbb.qna.repository;
 
-import com.example.zzbb.qna.entity.Likes;
+import com.example.zzbb.qna.entity.QnaLike;
 import com.example.zzbb.qna.entity.Qna;
 import com.example.zzbb.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,9 +11,9 @@ import java.util.ArrayList;
 import java.util.Optional;
 
 @Repository
-public interface LikeRepository extends JpaRepository<Likes, Integer> {
-    ArrayList<Likes> findByUser(User user);
+public interface LikeRepository extends JpaRepository<QnaLike, Integer> {
+    ArrayList<QnaLike> findByUser(User user);
 
-    @Query("SELECT l FROM Likes l WHERE l.user = :targetUser AND l.qna = :targetQna")
-    Optional<Likes> findByUserIdAndItemId(User targetUser, Qna targetQna);
+    @Query("SELECT l FROM QnaLike l WHERE l.user = :targetUser AND l.qna = :targetQna")
+    Optional<QnaLike> findByUserIdAndItemId(User targetUser, Qna targetQna);
 }

--- a/src/main/java/com/example/zzbb/qna/repository/ScrapRepository.java
+++ b/src/main/java/com/example/zzbb/qna/repository/ScrapRepository.java
@@ -1,7 +1,7 @@
 package com.example.zzbb.qna.repository;
 
 import com.example.zzbb.qna.entity.Qna;
-import com.example.zzbb.qna.entity.Scrap;
+import com.example.zzbb.qna.entity.QnaScrap;
 import com.example.zzbb.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,9 +11,9 @@ import java.util.ArrayList;
 import java.util.Optional;
 
 @Repository
-public interface ScrapRepository extends JpaRepository<Scrap, Integer> {
-    ArrayList<Scrap> findByUser(User user);
+public interface ScrapRepository extends JpaRepository<QnaScrap, Integer> {
+    ArrayList<QnaScrap> findByUser(User user);
 
-    @Query("SELECT s FROM Scrap s WHERE s.user = :targetUser AND s.qna = :targetQna")
-    Optional<Scrap> findByUserIdAndItemId(User targetUser, Qna targetQna);
+    @Query("SELECT s FROM QnaScrap s WHERE s.user = :targetUser AND s.qna = :targetQna")
+    Optional<QnaScrap> findByUserIdAndItemId(User targetUser, Qna targetQna);
 }

--- a/src/main/java/com/example/zzbb/qna/service/QnaService.java
+++ b/src/main/java/com/example/zzbb/qna/service/QnaService.java
@@ -65,7 +65,7 @@ public class QnaService {
                     qnaHashtagResponse,
                     qna.getQnaComments().size(),
                     qna.getQnaLikes().size(),
-                    qna.getScraps().size()
+                    qna.getQnaScraps().size()
             ));
         }
 
@@ -103,7 +103,7 @@ public class QnaService {
                 qnaImageResponse,
                 qna.getQnaComments().size(),
                 qna.getQnaLikes().size(),
-                qna.getScraps().size(),
+                qna.getQnaScraps().size(),
                 qnaCommentResponse
         );
 
@@ -143,15 +143,15 @@ public class QnaService {
 
         ScrapResponse response = new ScrapResponse();
 
-        Optional<Scrap> existingScrap = scrapRepository.findByUserIdAndItemId(targetUser, targetQna);
+        Optional<QnaScrap> existingScrap = scrapRepository.findByUserIdAndItemId(targetUser, targetQna);
         if (existingScrap.isPresent()) {
             scrapRepository.delete(existingScrap.get());
             response = new ScrapResponse(false);
         }
         else {
             // 1. 새로운 Scrap 생성
-            Scrap scrap = new Scrap(null, targetQna, targetUser);
-            Scrap saved = scrapRepository.save(scrap);
+            QnaScrap qnaScrap = new QnaScrap(null, targetQna, targetUser);
+            QnaScrap saved = scrapRepository.save(qnaScrap);
             // 2. 반환
             if (saved == null) return null;
             else response = new ScrapResponse(true);
@@ -209,7 +209,7 @@ public class QnaService {
                 hashtags,
                 new ArrayList<QnaComment>(),
                 new ArrayList<QnaLike>(),
-                new ArrayList<Scrap>(),
+                new ArrayList<QnaScrap>(),
                 formattedTime
         );
 

--- a/src/main/java/com/example/zzbb/qna/service/QnaService.java
+++ b/src/main/java/com/example/zzbb/qna/service/QnaService.java
@@ -63,8 +63,8 @@ public class QnaService {
                     qna.getTitle(),
                     qna.getBody(),
                     qnaHashtagResponse,
-                    qna.getComments().size(),
-                    qna.getLikes().size(),
+                    qna.getQnaComments().size(),
+                    qna.getQnaLikes().size(),
                     qna.getScraps().size()
             ));
         }
@@ -86,11 +86,11 @@ public class QnaService {
             qnaHashtagResponse.add(hashtag.getTag());
         for (QnaImage qnaImage : qna.getImages())
             qnaImageResponse.add(qnaImage.getUrl());
-        for (Comment comment : qna.getComments())
+        for (QnaComment qnaComment : qna.getQnaComments())
             qnaCommentResponse.add(
                     new CommentDto(
-                            comment.getBody(),
-                            comment.getGeneratedTime()
+                            qnaComment.getBody(),
+                            qnaComment.getGeneratedTime()
             ));
 
         // 2. response 형식으로 변환
@@ -101,8 +101,8 @@ public class QnaService {
                 qna.getBody(),
                 qnaHashtagResponse,
                 qnaImageResponse,
-                qna.getComments().size(),
-                qna.getLikes().size(),
+                qna.getQnaComments().size(),
+                qna.getQnaLikes().size(),
                 qna.getScraps().size(),
                 qnaCommentResponse
         );
@@ -118,16 +118,16 @@ public class QnaService {
 
         LikeResponse response = new LikeResponse();
 
-        Optional<Likes> existingLike = likeRepository.findByUserIdAndItemId(targetUser, targetQna);
-        if (existingLike.isPresent()) {
-            likeRepository.delete(existingLike.get());
+        Optional<QnaLike> existingQnaLike = likeRepository.findByUserIdAndItemId(targetUser, targetQna);
+        if (existingQnaLike.isPresent()) {
+            likeRepository.delete(existingQnaLike.get());
             response = new LikeResponse(false);
         }
         else {
             // 1. 새로운 Likes 생성
-            Likes like = new Likes(null, targetQna, targetUser);
+            QnaLike like = new QnaLike(null, targetQna, targetUser);
             // 2. 저장
-            Likes saved = likeRepository.save(like);
+            QnaLike saved = likeRepository.save(like);
             if (saved == null) return null;
             else response = new LikeResponse(true);
         }
@@ -160,7 +160,7 @@ public class QnaService {
         return response;
     }
 
-    public Comment commentQna(Integer qnaId, String username, QnaCommentRequest request) {
+    public QnaComment commentQna(Integer qnaId, String username, QnaCommentRequest request) {
         // 1. 새로운 Comment 생성
         Qna targetQna = qnaRepository.getReferenceById(qnaId);
         User targetUser = userRepository.findByUsername(username).orElse(null);
@@ -168,7 +168,7 @@ public class QnaService {
 
         LocalDateTime localDateTime = LocalDateTime.now();
         String formattedTime = localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
-        Comment comment = new Comment(
+        QnaComment qnaComment = new QnaComment(
                 null,
                 request.getBody(),
                 targetQna,
@@ -176,7 +176,7 @@ public class QnaService {
                 formattedTime);
 
         // 2. 저장
-        Comment response = commentRepository.save(comment);
+        QnaComment response = commentRepository.save(qnaComment);
         if (response == null) return null;
 
         // 3. 반환
@@ -207,8 +207,8 @@ public class QnaService {
                 targetUser,
                 null,
                 hashtags,
-                new ArrayList<Comment>(),
-                new ArrayList<Likes>(),
+                new ArrayList<QnaComment>(),
+                new ArrayList<QnaLike>(),
                 new ArrayList<Scrap>(),
                 formattedTime
         );

--- a/src/main/java/com/example/zzbb/user/service/MyPageService.java
+++ b/src/main/java/com/example/zzbb/user/service/MyPageService.java
@@ -1,28 +1,127 @@
 package com.example.zzbb.user.service;
 
-import com.example.zzbb.user.dto.mypage.MyHistoryResponse;
-import com.example.zzbb.user.dto.mypage.MyQnaResponse;
-import com.example.zzbb.user.dto.mypage.MyScrapResponse;
-import com.example.zzbb.user.dto.mypage.MyStatisticsResponse;
+import com.example.zzbb.db.repository.DbRepository;
+import com.example.zzbb.qna.entity.*;
+import com.example.zzbb.qna.repository.CommentRepository;
+import com.example.zzbb.qna.repository.LikeRepository;
+import com.example.zzbb.qna.repository.QnaRepository;
+import com.example.zzbb.qna.repository.ScrapRepository;
+import com.example.zzbb.user.dto.mypage.*;
+import com.example.zzbb.user.entity.User;
+import com.example.zzbb.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 
 @Service
+@RequiredArgsConstructor
 public class MyPageService {
+    private final QnaRepository qnaRepository;
+    private final DbRepository dbRepository;
+    private final CommentRepository commentRepository;
+    private final LikeRepository likeRepository;
+    private final ScrapRepository scrapRepository;
+    private final UserRepository userRepository;
+
     public MyStatisticsResponse getMyStatistics(String username) {
-        return null;
+        // 1. 유저 정보 가져오기
+        User user = userRepository.findByUsername(username).orElse(null);
+        if (user == null) return  null;
+
+        // 2. qna, db, reactions 정보 가져오기
+        ArrayList<Qna> questions = qnaRepository.findByUser(user);
+        ArrayList<QnaComment> qnaComments = commentRepository.findByUser(user);
+        ArrayList<QnaLike> qnaLikes = likeRepository.findByUser(user);
+        ArrayList<Scrap> scraps = scrapRepository.findByUser(user);
+
+        // 3. response에 담기
+        MyStatisticsResponse response = new MyStatisticsResponse(
+                questions.size(),
+                qnaComments.size(),
+                qnaLikes.size()+scraps.size()
+        );
+        // 4. 반환
+        return response;
     }
 
     public MyHistoryResponse getMyHistory(String username) {
-        return null;
+        // 1. 유저 정보 가져오기
+        User user = userRepository.findByUsername(username).orElse(null);
+        if (user == null) return  null;
+
+        // 2. 작성글, 스크랩글 정보 받아오기
+        ArrayList<Qna> wroteArticles = qnaRepository.findByUser(user);
+        ArrayList<Scrap> scrapedArticles = scrapRepository.findByUser(user);
+
+        // 3. response에 담기
+        MyHistoryResponse response = new MyHistoryResponse(
+                wroteArticles.size(),
+                scrapedArticles.size()
+        );
+        // 4. 반환
+        return response;
     }
 
     public ArrayList<MyQnaResponse> getMyQna(String username) {
-        return null;
+        // 1. 유저 정보 가져오기
+        User user = userRepository.findByUsername(username).orElse(null);
+        if (user == null) return  null;
+
+        // 2. 유저 정보로 Qna 가져오기
+        ArrayList<Qna> qnas = qnaRepository.findByUser(user);
+
+        // 3. response에 담기
+        ArrayList<MyQnaResponse> responses = new ArrayList<>();
+        for (Qna qna : qnas) {
+            ArrayList<String> qnaImagesResponse = new ArrayList<>();
+            for (QnaImage qnaImage : qna.getImages())
+                qnaImagesResponse.add(qnaImage.getUrl());
+            responses.add(new MyQnaResponse(
+                    qna.getQnaId(),
+                    qna.getTitle(),
+                    qna.getBody(),
+                    qnaImagesResponse,
+                    qna.getQnaComments().size(),
+                    qna.getQnaLikes().size(),
+                    qna.getScraps().size()
+            ));
+        }
+        // 4. 반환
+        return responses;
     }
 
     public ArrayList<MyScrapResponse> getMyScrap(String username) {
+        // 1. 유저 정보 가져오기
+        User user = userRepository.findByUsername(username).orElse(null);
+        if (user == null) return  null;
+
+        // 2. 유저 정보로 Qna 가져오기
+        ArrayList<Scrap> scraps = scrapRepository.findByUser(user);
+        ArrayList<Qna> qnas = new ArrayList<>();
+        for (Scrap scrap : scraps) qnas.add(scrap.getQna());
+
+        // 3. response에 담기
+        ArrayList<MyScrapResponse> responses = new ArrayList<>();
+        for (Qna qna : qnas){
+            ArrayList<String> qnaImagesResponse = new ArrayList<>();
+            for (QnaImage qnaImage : qna.getImages())
+                qnaImagesResponse.add(qnaImage.getUrl());
+            responses.add(new MyScrapResponse(
+                    qna.getQnaId(),
+                    qna.getTitle(),
+                    qna.getBody(),
+                    qnaImagesResponse,
+                    qna.getQnaComments().size(),
+                    qna.getQnaLikes().size(),
+                    qna.getScraps().size()
+            ));
+        }
+        // 4. 반환
+        return responses;
+    }
+
+    public MyBadgeResponse getMyBadge(String username) {
         return null;
     }
 }

--- a/src/main/java/com/example/zzbb/user/service/MyPageService.java
+++ b/src/main/java/com/example/zzbb/user/service/MyPageService.java
@@ -33,13 +33,13 @@ public class MyPageService {
         ArrayList<Qna> questions = qnaRepository.findByUser(user);
         ArrayList<QnaComment> qnaComments = commentRepository.findByUser(user);
         ArrayList<QnaLike> qnaLikes = likeRepository.findByUser(user);
-        ArrayList<Scrap> scraps = scrapRepository.findByUser(user);
+        ArrayList<QnaScrap> qnaScraps = scrapRepository.findByUser(user);
 
         // 3. response에 담기
         MyStatisticsResponse response = new MyStatisticsResponse(
                 questions.size(),
                 qnaComments.size(),
-                qnaLikes.size()+scraps.size()
+                qnaLikes.size()+ qnaScraps.size()
         );
         // 4. 반환
         return response;
@@ -52,7 +52,7 @@ public class MyPageService {
 
         // 2. 작성글, 스크랩글 정보 받아오기
         ArrayList<Qna> wroteArticles = qnaRepository.findByUser(user);
-        ArrayList<Scrap> scrapedArticles = scrapRepository.findByUser(user);
+        ArrayList<QnaScrap> scrapedArticles = scrapRepository.findByUser(user);
 
         // 3. response에 담기
         MyHistoryResponse response = new MyHistoryResponse(
@@ -84,7 +84,7 @@ public class MyPageService {
                     qnaImagesResponse,
                     qna.getQnaComments().size(),
                     qna.getQnaLikes().size(),
-                    qna.getScraps().size()
+                    qna.getQnaScraps().size()
             ));
         }
         // 4. 반환
@@ -97,9 +97,9 @@ public class MyPageService {
         if (user == null) return  null;
 
         // 2. 유저 정보로 Qna 가져오기
-        ArrayList<Scrap> scraps = scrapRepository.findByUser(user);
+        ArrayList<QnaScrap> qnaScraps = scrapRepository.findByUser(user);
         ArrayList<Qna> qnas = new ArrayList<>();
-        for (Scrap scrap : scraps) qnas.add(scrap.getQna());
+        for (QnaScrap qnaScrap : qnaScraps) qnas.add(qnaScrap.getQna());
 
         // 3. response에 담기
         ArrayList<MyScrapResponse> responses = new ArrayList<>();
@@ -114,7 +114,7 @@ public class MyPageService {
                     qnaImagesResponse,
                     qna.getQnaComments().size(),
                     qna.getQnaLikes().size(),
-                    qna.getScraps().size()
+                    qna.getQnaScraps().size()
             ));
         }
         // 4. 반환


### PR DESCRIPTION
# Task Summary (*필수)
* DB에 like, scrap column이 추가되어서 qna의 like, scrap, comment 엔티티의 이름을 변경했습니다

# Changes (*필수)
* Like > QnaLike
* Scrap > QnaScrap
* Comment > QnaComment

# PR 유형 (*필수)
- [ ] Bug Fix (fix)
- [ ] New Features (feat)
- [ ] Test (test)
- [ ] Document modification (docs)
- [X] Refactoring (refactor)
- [ ] Styling (style)
- [ ] ETC, No production code change (chore)
- [ ] Build task and Dependency management (build)

# Screenshot

# Reference
